### PR TITLE
При последовательном изменении поля на новое значение, а потом обратно на старое флаг измененности поля не сбрасывался

### DIFF
--- a/lib/globalize/model/active_record.rb
+++ b/lib/globalize/model/active_record.rb
@@ -26,7 +26,6 @@ module Globalize
               return send("#{attr_name}_translations_hash=", val) if val.is_a? Hash
 
               current = globalize.fetch_without_fallbacks(self.class.locale, attr_name)
-              attribute_will_change!(attr_name) if current != val
               globalize.stash self.class.locale, attr_name, val
               write_attribute(attr_name, val)
             }

--- a/test/model/active_record/translated_test.rb
+++ b/test/model/active_record/translated_test.rb
@@ -345,6 +345,16 @@ class TranslatedTest < ActiveSupport::TestCase
     assert_equal [:subject], post.changed.map(&:to_sym)
   end
 
+  test 'clear changed flag after return original value' do
+    post = Post.create subject: 'foo', content: 'bar'
+    assert_equal [], post.changed
+    original_subject = post.subject
+    post.subject = 'foo!'
+    assert_equal ['subject'], post.changed
+    post.subject = original_subject
+    assert_equal [], post.changed
+  end
+
   # Противоречит тесту
   # "resolves a complex fallback without reloading"
   test 'fallbacks with lots of locale switching' do


### PR DESCRIPTION
Принудительно помечать атрибут измененным не надо, т.к. это выполняется внутри write_attribute стандартными механизмами rails.

Воспроизведение:
1. Меняем атрибут на новое значение. Все методы, проверяющие измененность поля (changed?, attribute_chaned?, changes и т.д.), говорят, что поле изменено.
2. Возвращаем полю старое значение. Но поле все равно считается измененным. Хотя для обычных полей ActiveRecord в такой ситуации поле перестает считаться измененным.

Пример:
<img width="454" alt="image" src="https://github.com/insales/globalize/assets/7142331/8c1826f4-df0d-4ac6-8c2c-6f87093f2416">

После фикса:
<img width="446" alt="image" src="https://github.com/insales/globalize/assets/7142331/3ab8cf42-09cd-4912-92a7-66f4459d2a0b">

Проблема выстреливает массово для полей, для которых выполняется какая то чистка или нормализация перед сохранением через before колбэки. Например, для полей со `strip_attributes!`. Например, когда в файле импорта значение указано с лишними пробелами в конце. Сначала значение читается из файла и передается в модель в сыром виде. Поле помечается измененным. Потом при сохранении, пробелы удаляются и значение становится идентично тому, что и было в базе. Но флаг изменения не сбрасывается и все проверки говорят, что в модели есть изменения. В итоге мы делаем лишние запросы в базу на сохранение модели и создаем лишние записи в истории изменения товаров. 

