### PR TITLE
Уменьшаем алокацию объектов за счет замороженных строк

### DIFF
--- a/lib/globalize.rb
+++ b/lib/globalize.rb
@@ -1,4 +1,5 @@
-# -*- encoding : utf-8 -*-
+# frozen_string_literal: true
+
 require 'globalize/load_path'
 require 'globalize/backend/static'
 require 'globalize/model/active_record'

--- a/lib/globalize/backend/chain.rb
+++ b/lib/globalize/backend/chain.rb
@@ -1,4 +1,5 @@
-# -*- encoding : utf-8 -*-
+# frozen_string_literal: true
+
 module I18n
   class << self
     def chain_backends(*args)

--- a/lib/globalize/backend/pluralizing.rb
+++ b/lib/globalize/backend/pluralizing.rb
@@ -1,4 +1,5 @@
-# -*- encoding : utf-8 -*-
+# frozen_string_literal: true
+
 require 'i18n/backend/simple'
 
 module Globalize

--- a/lib/globalize/backend/static.rb
+++ b/lib/globalize/backend/static.rb
@@ -1,4 +1,5 @@
-# -*- encoding : utf-8 -*-
+# frozen_string_literal: true
+
 require 'globalize/backend/pluralizing'
 require 'globalize/locale/fallbacks'
 require 'globalize/translation'

--- a/lib/globalize/i18n/missing_translations_log_handler.rb
+++ b/lib/globalize/i18n/missing_translations_log_handler.rb
@@ -1,4 +1,5 @@
-# -*- encoding : utf-8 -*-
+# frozen_string_literal: true
+
 # A simple exception handler that behaves like the default exception handler
 # but additionally logs missing translations to a given log.
 #

--- a/lib/globalize/i18n/missing_translations_raise_handler.rb
+++ b/lib/globalize/i18n/missing_translations_raise_handler.rb
@@ -1,4 +1,5 @@
-# -*- encoding : utf-8 -*-
+# frozen_string_literal: true
+
 # A simple exception handler that behaves like the default exception handler
 # but also raises on missing translations.
 #

--- a/lib/globalize/load_path.rb
+++ b/lib/globalize/load_path.rb
@@ -1,4 +1,5 @@
-# -*- encoding : utf-8 -*-
+# frozen_string_literal: true
+
 # Locale load_path and Locale loading support.
 #
 # To use this include the Globalize::LoadPath::I18n module to I18n like this:
@@ -14,16 +15,16 @@
 #
 #   I18n.load_locales 'en-US', 'de-DE'
 #   I18n.load_locale 'en-US'
-# 
+#
 # This will lookup all files named like:
 #
 #   'path/to/dir/all.yml'
 #   'path/to/dir/en-US.yml'
 #   'path/to/dir/en-US/*.yml'
 #
-# The filenames will be passed to I18n.load_translations which delegates to 
+# The filenames will be passed to I18n.load_translations which delegates to
 # the backend. So the actual behaviour depends on the implementation of the
-# backend. I18n::Backend::Simple will be able to read YAML and plain Ruby 
+# backend. I18n::Backend::Simple will be able to read YAML and plain Ruby
 # files. See the documentation for I18n.load_translations for details.
 
 module Globalize
@@ -32,27 +33,27 @@ module Globalize
       @extensions ||= ['rb', 'yml']
     end
     attr_writer :extensions
-  
+
     def locales
       @locales ||= ['*']
     end
     attr_writer :locales
-  
+
     def <<(path)
       push path
     end
-  
+
     def push(*paths)
       super(*paths.map{|path| filenames(path) }.flatten.uniq.sort)
     end
-  
+
     protected
-  
+
       def filenames(path)
         return [path] if File.file? path
         patterns(path).map{|pattern| Dir[pattern] }
       end
-  
+
       def patterns(path)
         locales.map do |locale|
           extensions.map do |extension|

--- a/lib/globalize/locale/active_record.rb
+++ b/lib/globalize/locale/active_record.rb
@@ -1,4 +1,5 @@
-# -*- encoding : utf-8 -*-
+# frozen_string_literal: true
+
 module I18n
   @@ar_fallbacks  = nil
   @@ar_locale     = nil

--- a/lib/globalize/locale/fallbacks.rb
+++ b/lib/globalize/locale/fallbacks.rb
@@ -1,4 +1,5 @@
-# -*- encoding : utf-8 -*-
+# frozen_string_literal: true
+
 require 'globalize/locale/language_tag'
 
 module I18n

--- a/lib/globalize/locale/language_tag.rb
+++ b/lib/globalize/locale/language_tag.rb
@@ -1,4 +1,5 @@
-# -*- encoding : utf-8 -*-
+# frozen_string_literal: true
+
 # for specifications see http://en.wikipedia.org/wiki/IETF_language_tag
 #
 # SimpleParser does not implement advanced usages such as grandfathered tags

--- a/lib/globalize/model/active_record.rb
+++ b/lib/globalize/model/active_record.rb
@@ -1,4 +1,5 @@
-# -*- encoding : utf-8 -*-
+# frozen_string_literal: true
+
 require 'active_support/core_ext/object/deep_dup'
 require 'globalize/translation'
 require 'globalize/locale/fallbacks'

--- a/lib/globalize/model/active_record/languages.rb
+++ b/lib/globalize/model/active_record/languages.rb
@@ -1,4 +1,5 @@
-# -*- encoding : utf-8 -*-
+# frozen_string_literal: true
+
 module I18n
   @@languages = nil
   @@languages_array = nil

--- a/lib/globalize/model/active_record/postgres_array.rb
+++ b/lib/globalize/model/active_record/postgres_array.rb
@@ -1,4 +1,5 @@
-# -*- encoding : utf-8 -*-
+# frozen_string_literal: true
+
 module Globalize
   module Model
     module ActiveRecord

--- a/lib/globalize/model/active_record/translated.rb
+++ b/lib/globalize/model/active_record/translated.rb
@@ -1,4 +1,5 @@
-# -*- encoding : utf-8 -*-
+# frozen_string_literal: true
+
 module Globalize
   module Model
 

--- a/lib/globalize/translation.rb
+++ b/lib/globalize/translation.rb
@@ -1,4 +1,5 @@
-# -*- encoding : utf-8 -*-
+# frozen_string_literal: true
+
 module Globalize
   # Translations are simple value objects that carry some context information
   # alongside the actual translation string.
@@ -7,25 +8,25 @@ module Globalize
     class Attribute < Translation
       attr_accessor :requested_locale, :locale, :key
     end
-    
+
     class Static < Translation
       attr_accessor :requested_locale, :locale, :key, :options, :plural_key, :original
-      
+
       def initialize(string, meta = nil)
         self.original = string
         super
       end
     end
-    
+
     def initialize(string, meta = nil)
       set_meta meta
       super string
     end
-  
+
     def fallback?
       locale.to_sym != requested_locale.to_sym
     end
-    
+
     def set_meta(meta)
       meta.each {|name, value| send :"#{name}=", value } if meta
     end

--- a/lib/rails_edge_load_path_patch.rb
+++ b/lib/rails_edge_load_path_patch.rb
@@ -1,13 +1,14 @@
-# -*- encoding : utf-8 -*-
+# frozen_string_literal: true
+
 module I18n
   @@load_path = nil
   @@default_locale = :'en-US'
-  
+
   class << self
     def load_path
       @@load_path ||= []
     end
-    
+
     def load_path=(load_path)
       @@load_path = load_path
     end
@@ -18,14 +19,14 @@ I18n::Backend::Simple.module_eval do
   def initialized?
     @initialized ||= false
   end
-  
+
   protected
 
     def init_translations
       load_translations(*I18n.load_path)
       @initialized = true
     end
-    
+
     def lookup(locale, key, scope = [])
       return unless key
       init_translations unless initialized?
@@ -35,7 +36,7 @@ I18n::Backend::Simple.module_eval do
 end
 
 rails_dir = File.expand_path "#{File.dirname(__FILE__)}/../../../rails/"
-paths = %w(actionpack/lib/action_view/locale/en-US.yml 
+paths = %w(actionpack/lib/action_view/locale/en-US.yml
            activerecord/lib/active_record/locale/en-US.yml
            activesupport/lib/active_support/locale/en-US.yml)
 paths.each{|path| I18n.load_path << "#{rails_dir}/#{path}" }


### PR DESCRIPTION
Основное здесь это `globalize/model/active_record/postgres_array.rb`. Там много используются строковые литералы внутри методов, а методы достаточно активно вызываются при взаимодействии с локализованными полями.