### PR TITLE
Делаю наши дополнения к I18n более потокобезопасными

### DIFF
--- a/lib/globalize/locale/active_record.rb
+++ b/lib/globalize/locale/active_record.rb
@@ -1,39 +1,36 @@
 # frozen_string_literal: true
 
 module I18n
-  @@ar_fallbacks  = nil
-  @@ar_locale     = nil
-
   class << self
     def ar_locale
-      @@ar_locale || locale
+      Thread.current[:ar_locale] || locale
     end
 
     def ar_locale=(val)
       raise ::ArgumentError, "No language for locale `#{val}'" if !val.nil? && !I18n.language(val)
 
-      @@ar_locale = val
+      Thread.current[:ar_locale] = val
     end
 
     def reset_ar_locale
-      @@ar_locale     = nil
+      Thread.current[:ar_locale] = nil
       self
     end
 
     # Returns the current fallbacks. Defaults to +Globalize::Locale::Fallbacks+.
     def ar_fallbacks(force = false)
-      return @@ar_fallbacks if @@ar_fallbacks
+      return Thread.current[:ar_fallbacks] if Thread.current[:ar_fallbacks]
       return fallbacks unless force
-      @@ar_fallbacks = Globalize::Locale::Fallbacks.new
+      Thread.current[:ar_fallbacks] = Globalize::Locale::Fallbacks.new
     end
 
     # Sets the current fallbacks. Used to set a custom fallbacks instance.
     def ar_fallbacks=(fallbacks)
-      @@ar_fallbacks = fallbacks
+      Thread.current[:ar_fallbacks] = fallbacks
     end
 
     def reset_ar_fallbacks
-      @@ar_fallbacks = nil
+      Thread.current[:ar_fallbacks] = nil
       self
     end
   end

--- a/lib/globalize/locale/fallbacks.rb
+++ b/lib/globalize/locale/fallbacks.rb
@@ -3,21 +3,19 @@
 require 'globalize/locale/language_tag'
 
 module I18n
-  @@fallbacks = nil
-
   class << self
     # Returns the current fallbacks. Defaults to +Globalize::Locale::Fallbacks+.
     def fallbacks
-      @@fallbacks ||= Globalize::Locale::Fallbacks.new
+      Thread.current[:fallbacks] ||= Globalize::Locale::Fallbacks.new
     end
 
     # Sets the current fallbacks. Used to set a custom fallbacks instance.
     def fallbacks=(fallbacks)
-      @@fallbacks = fallbacks
+      Thread.current[:fallbacks] = fallbacks
     end
 
     def reset_fallbacks
-      @@fallbacks = nil
+      Thread.current[:fallbacks] = nil
       self
     end
   end

--- a/lib/globalize/locale/language_tag.rb
+++ b/lib/globalize/locale/language_tag.rb
@@ -14,11 +14,11 @@ module Globalize
     class LanguageTag < Struct.new(*Rfc4646::SUBTAGS)
       class << self
         def parser
-          @@parser ||= SimpleParser
+          Thread.current[:parser] ||= SimpleParser
         end
 
         def parser=(parser)
-          @@parser = parser
+          Thread.current[:parser] = parser
         end
 
         def tag(tag)

--- a/lib/globalize/model/active_record/translated.rb
+++ b/lib/globalize/model/active_record/translated.rb
@@ -75,11 +75,11 @@ module Globalize
           end
 
           def locale=(locale)
-            @@locale = locale
+            Thread.current[:locale] = locale
           end
 
           def locale
-            (defined?(@@locale) && @@locale) || I18n.ar_locale
+            Thread.current[:locale] || I18n.ar_locale
           end
         end
 

--- a/test/locale/fallbacks_test.rb
+++ b/test/locale/fallbacks_test.rb
@@ -36,6 +36,17 @@ class FallbacksTest < ActiveSupport::TestCase
     I18n.fallbacks = Fallbacks.new(:'fi-FI', :'se-FI')
     assert_equal(%i[fi-FI fi se-FI se root], I18n.fallbacks.defaults)
   end
+
+  test "thread safety" do
+    I18n.fallbacks[:es] = [:en]
+    assert_equal({ es: [:en] }, I18n.fallbacks)
+    thread = Thread.new do
+      I18n.fallbacks[:en] = [:us]
+      assert_equal({ en: [:us] }, I18n.fallbacks)
+    end
+    thread.join
+    assert_equal({ es: [:en] }, I18n.fallbacks)
+  end
 end
 
 class NoMappingFallbacksTest < ActiveSupport::TestCase

--- a/test/model/active_record/translated_test.rb
+++ b/test/model/active_record/translated_test.rb
@@ -431,8 +431,6 @@ class TranslatedTest < ActiveSupport::TestCase
   end
 
   test "access content locale before setting" do
-    Globalize::Model::ActiveRecord::Translated::ActMethods.class_eval "remove_class_variable(:@@locale)", __FILE__,
-                                                                      __LINE__ - 1
     assert_nothing_raised { ActiveRecord::Base.locale }
   end
 


### PR DESCRIPTION
Избавляюсь от использования глобальных переменных. В I18n.languages пока оставил, т.к. иначе придется инициализировать языки в каждом потоке заново. Но т.к. языки мы инициализируем один раз в инитиалайзере, то кажется из-за languages не должно быть проблем.